### PR TITLE
Convert heatmap to bar chart and use log scale

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1000,19 +1000,6 @@ def create_comprehensive_data_overview(df):
         else:
             return f"{value:.2f}"
 
-    # Management summary for decision makers
-    st.markdown("### 🏢 Management Summary")
-    region_totals = df.groupby('Region')['sales_volume'].sum()
-    product_totals = df.groupby('Product')['sales_volume'].sum()
-    top_region = region_totals.idxmax()
-    top_region_vol = format_value_with_unit(region_totals.max())
-    top_product = product_totals.idxmax()
-    top_product_vol = format_value_with_unit(product_totals.max())
-    st.markdown(
-        f"- **Top Region by Sales Volume:** {top_region} ({top_region_vol} litres)\n"
-        f"- **Top Product by Sales Volume:** {top_product} ({top_product_vol} litres)"
-    )
-
     # Visualizations
     st.markdown("### 📊 Sales Volume Analysis")
     
@@ -1097,30 +1084,35 @@ def create_comprehensive_data_overview(df):
         return fig_product
 
     @st.cache_data(ttl=3600)
-    def create_heatmap(df):
-        pivot_data = df.groupby(['Region', 'Product'])['sales_volume'].sum().unstack(fill_value=0)
-        formatted_values = []
-        for row in pivot_data.values:
-            formatted_row = [format_value_with_unit(val) for val in row]
-            formatted_values.append(formatted_row)
-        fig_heatmap = px.imshow(
-            pivot_data,
-            title='Weekly Sales Volume Heatmap: Region vs Product',
-            labels=dict(x='Product', y='Region', color='Weekly Sales Volume (Litres)'),
-            aspect='auto',
+    def create_region_product_chart(df):
+        comparison_data = (
+            df.groupby(['Region', 'Product'])['sales_volume']
+            .sum()
+            .reset_index()
         )
-        fig_heatmap.data[0].customdata = formatted_values
-        fig_heatmap.update_traces(
-            hovertemplate='Region: %{y}<br>Product: %{x}<br>Sales Volume: %{z:.2f} (%{customdata})<extra></extra>'
+        comparison_data['formatted_volume'] = comparison_data['sales_volume'].apply(format_value_with_unit)
+        fig_compare = px.bar(
+            comparison_data,
+            x='Region',
+            y='sales_volume',
+            color='Product',
+            barmode='group',
+            title='Weekly Sales Volume: Region vs Product',
+            labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
+            custom_data=['formatted_volume']
         )
-        fig_heatmap.update_layout(
+        fig_compare.update_traces(
+            hovertemplate='Region: %{x}<br>Product: %{fullData.name}<br>Sales Volume: %{y:.2f} (%{customdata[0]})<extra></extra>'
+        )
+        fig_compare.update_layout(
             height=600,
             width=800,
-            template='plotly_white'
+            template='plotly_white',
+            yaxis_type='log'
         )
-        return fig_heatmap
+        return fig_compare
 
-    tab_region, tab_product, tab_heatmap = st.tabs(["By Region", "By Product", "Region vs Product"])
+    tab_region, tab_product, tab_compare = st.tabs(["By Region", "By Product", "Region vs Product"])
     with tab_region:
         fig_region = create_region_volume_chart(df)
         st.plotly_chart(fig_region, use_container_width=True)
@@ -1128,9 +1120,9 @@ def create_comprehensive_data_overview(df):
         product_df = create_product_volume_chart(df)
         fig_product = create_product_chart(product_df)
         st.plotly_chart(fig_product, use_container_width=True)
-    with tab_heatmap:
-        fig_heatmap = create_heatmap(df)
-        st.plotly_chart(fig_heatmap, use_container_width=True)
+    with tab_compare:
+        fig_region_product = create_region_product_chart(df)
+        st.plotly_chart(fig_region_product, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1164,7 +1156,9 @@ def create_comprehensive_data_overview(df):
         fig_monthly.update_layout(
             height=450,
             width=800,
-            template='plotly_white'
+            template='plotly_white',
+            yaxis_type='log',
+            yaxis_title='Monthly Sales Volume (Litres, Log Scale)'
         )
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly


### PR DESCRIPTION
## Summary
- Remove management summary section from analysis page
- Replace Region vs Product heatmap with grouped bar chart using logarithmic scaling to display low-volume products
- Apply logarithmic scale to monthly sales volume trend to better visualize HOBC alongside larger products

## Testing
- `python -m py_compile main_final.py`

------
https://chatgpt.com/codex/tasks/task_e_68950b8b1fec832a92ac0ba826e6b5d7