### PR TITLE
feat: streamline chart toggles and styling

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1011,6 +1011,14 @@ def create_comprehensive_data_overview(df):
         else:
             return str(int(value))
 
+    def get_lagged_tick_vals(max_val: float) -> list:
+        """Generate sparse tick values for lagged charts."""
+        ticks = [90_000_000, 100_000_000, 200_000_000, 300_000_000, 400_000_000]
+        if max_val > 400_000_000:
+            num_billions = int(np.ceil(max_val / 1_000_000_000))
+            ticks.extend([1_000_000_000 * i for i in range(1, num_billions + 1)])
+        return [t for t in ticks if t <= max_val]
+
     # Visualizations
     st.markdown("### 📊 Sales Volume Analysis")
     
@@ -1029,28 +1037,30 @@ def create_comprehensive_data_overview(df):
         
         fig_region = px.bar(
             data_frame=region_df,
-            x='Region',
-            y='sales_volume',
+            y='Region',
+            x='sales_volume',
+            orientation='h',
             title='Total Weekly Sales Volume by Region',
             labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
             color='sales_volume',
-            color_continuous_scale='viridis',
+            color_continuous_scale=px.colors.sequential.Blues,
             custom_data='formatted_volume'
         )
         fig_region.update_traces(
-            hovertemplate='Region: %{x}<br>Sales Volume: %{y:.2f} (%{customdata})<extra></extra>'
+            hovertemplate='Region: %{y}<br>Sales Volume: %{x:.2f} (%{customdata})<extra></extra>'
         )
         fig_region.update_layout(
-            height=500,
+            height=400,
             width=800,
             template='plotly_white',
             font=dict(size=14),
             title_font_size=18,
+            xaxis_title='Weekly Sales Volume (Litres)',
             xaxis_title_font_size=14,
-            yaxis_title='Weekly Sales Volume (Litres)',
-            yaxis_title_font_size=14
+            yaxis_title_font_size=14,
+            coloraxis_showscale=False,
+            showlegend=False
         )
-        fig_region.update_xaxes(tickangle=45)
         return fig_region
     
     @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -1095,7 +1105,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = product_df['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = get_lagged_tick_vals(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_product.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_product.update_xaxes(tickangle=45)
@@ -1127,7 +1137,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = rp_data['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = get_lagged_tick_vals(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_rp.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_rp.update_xaxes(tickangle=45)
@@ -1139,21 +1149,13 @@ def create_comprehensive_data_overview(df):
         st.plotly_chart(fig_region, use_container_width=True)
     with tab_product:
         product_df = create_product_volume_chart(df)
-        sub_normal, sub_lagged = st.tabs(["Normal", "Lagged"])
-        with sub_normal:
-            fig_product = create_product_chart(product_df)
-            st.plotly_chart(fig_product, use_container_width=True)
-        with sub_lagged:
-            fig_product_lag = create_product_chart(product_df, log_y=True)
-            st.plotly_chart(fig_product_lag, use_container_width=True)
+        show_lag_product = st.toggle("Lagged values", key="product_lag_toggle")
+        fig_product = create_product_chart(product_df, log_y=show_lag_product)
+        st.plotly_chart(fig_product, use_container_width=True)
     with tab_region_product:
-        rp_normal, rp_lagged = st.tabs(["Normal", "Lagged"])
-        with rp_normal:
-            fig_rp = create_region_product_chart(df)
-            st.plotly_chart(fig_rp, use_container_width=True)
-        with rp_lagged:
-            fig_rp_log = create_region_product_chart(df, log_y=True)
-            st.plotly_chart(fig_rp_log, use_container_width=True)
+        show_lag_rp = st.toggle("Lagged values", key="region_product_lag_toggle")
+        fig_rp = create_region_product_chart(df, log_y=show_lag_rp)
+        st.plotly_chart(fig_rp, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1192,19 +1194,15 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = df_monthly['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = get_lagged_tick_vals(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_monthly.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly
 
-    month_normal, month_lagged = st.tabs(["Normal", "Lagged"])
-    with month_normal:
-        fig_monthly = create_monthly_sales_chart(df)
-        st.plotly_chart(fig_monthly, use_container_width=True)
-    with month_lagged:
-        fig_monthly_log = create_monthly_sales_chart(df, log_y=True)
-        st.plotly_chart(fig_monthly_log, use_container_width=True)
+    show_month_lag = st.toggle("Lagged values", key="monthly_lag_toggle")
+    fig_monthly = create_monthly_sales_chart(df, log_y=show_month_lag)
+    st.plotly_chart(fig_monthly, use_container_width=True)
 
     st.markdown("### 💰 Monthly Average Price Trend by Fuel Type")
     


### PR DESCRIPTION
## Summary
- Replace region bar chart with compact horizontal layout using a blue gradient and no legend
- Simplify normal/lagged view selection with single toggles
- Apply sparse milestone ticks (90M, 100M, 200M, 300M, 400M, 1B, 2B, …) across lagged charts

## Testing
- `python -m py_compile main_final.py`


------
https://chatgpt.com/codex/tasks/task_e_6895220a293c832aaf54ebeb45299024