### PR TITLE
Refine chart layouts and lagged value toggles

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1011,6 +1011,17 @@ def create_comprehensive_data_overview(df):
         else:
             return str(int(value))
 
+    def generate_ticks(max_val: float) -> tuple[list[float], list[str]]:
+        """Generate simplified tick values and labels for large numbers."""
+        base_ticks = [9e7, 1e8, 2e8, 3e8, 4e8]
+        tick_vals = [v for v in base_ticks if v <= max_val]
+        current = 1e9
+        while current <= max_val:
+            tick_vals.append(current)
+            current += 1e9
+        tick_text = [format_tick(v) for v in tick_vals]
+        return tick_vals, tick_text
+
     # Visualizations
     st.markdown("### 📊 Sales Volume Analysis")
     
@@ -1019,26 +1030,27 @@ def create_comprehensive_data_overview(df):
     def create_region_volume_chart(df):
         # Sales volume by region
         region_volume = df.groupby('Region')['sales_volume'].sum().sort_values(ascending=False)
-        
+
         # Create a DataFrame for px.bar
         region_df = pd.DataFrame({
             'Region': region_volume.index,
             'sales_volume': region_volume.values,
             'formatted_volume': [format_value_with_unit(val) for val in region_volume.values]
         })
-        
+
         fig_region = px.bar(
             data_frame=region_df,
-            x='Region',
-            y='sales_volume',
+            x='sales_volume',
+            y='Region',
+            orientation='h',
             title='Total Weekly Sales Volume by Region',
-            labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
+            labels={'sales_volume': 'Weekly Sales Volume (Litres)', 'Region': 'Region'},
             color='sales_volume',
-            color_continuous_scale='viridis',
+            color_continuous_scale='Blues',
             custom_data='formatted_volume'
         )
         fig_region.update_traces(
-            hovertemplate='Region: %{x}<br>Sales Volume: %{y:.2f} (%{customdata})<extra></extra>'
+            hovertemplate='Region: %{y}<br>Sales Volume: %{x:.2f} (%{customdata})<extra></extra>'
         )
         fig_region.update_layout(
             height=500,
@@ -1046,11 +1058,12 @@ def create_comprehensive_data_overview(df):
             template='plotly_white',
             font=dict(size=14),
             title_font_size=18,
+            xaxis_title='Weekly Sales Volume (Litres)',
             xaxis_title_font_size=14,
-            yaxis_title='Weekly Sales Volume (Litres)',
-            yaxis_title_font_size=14
+            yaxis_title=None,
+            coloraxis_showscale=False,
+            showlegend=False
         )
-        fig_region.update_xaxes(tickangle=45)
         return fig_region
     
     @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -1095,8 +1108,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = product_df['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
-            tick_text = [format_tick(v) for v in tick_vals]
+            tick_vals, tick_text = generate_ticks(max_val)
             fig_product.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_product.update_xaxes(tickangle=45)
         return fig_product
@@ -1127,8 +1139,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = rp_data['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
-            tick_text = [format_tick(v) for v in tick_vals]
+            tick_vals, tick_text = generate_ticks(max_val)
             fig_rp.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_rp.update_xaxes(tickangle=45)
         return fig_rp
@@ -1139,21 +1150,13 @@ def create_comprehensive_data_overview(df):
         st.plotly_chart(fig_region, use_container_width=True)
     with tab_product:
         product_df = create_product_volume_chart(df)
-        sub_normal, sub_lagged = st.tabs(["Normal", "Lagged"])
-        with sub_normal:
-            fig_product = create_product_chart(product_df)
-            st.plotly_chart(fig_product, use_container_width=True)
-        with sub_lagged:
-            fig_product_lag = create_product_chart(product_df, log_y=True)
-            st.plotly_chart(fig_product_lag, use_container_width=True)
+        show_product_lag = st.toggle("Show Lagged Values", key="product_lag_toggle")
+        fig_product = create_product_chart(product_df, log_y=show_product_lag)
+        st.plotly_chart(fig_product, use_container_width=True)
     with tab_region_product:
-        rp_normal, rp_lagged = st.tabs(["Normal", "Lagged"])
-        with rp_normal:
-            fig_rp = create_region_product_chart(df)
-            st.plotly_chart(fig_rp, use_container_width=True)
-        with rp_lagged:
-            fig_rp_log = create_region_product_chart(df, log_y=True)
-            st.plotly_chart(fig_rp_log, use_container_width=True)
+        show_rp_lag = st.toggle("Show Lagged Values", key="rp_lag_toggle")
+        fig_rp = create_region_product_chart(df, log_y=show_rp_lag)
+        st.plotly_chart(fig_rp, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1192,19 +1195,14 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = df_monthly['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
-            tick_text = [format_tick(v) for v in tick_vals]
+            tick_vals, tick_text = generate_ticks(max_val)
             fig_monthly.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly
 
-    month_normal, month_lagged = st.tabs(["Normal", "Lagged"])
-    with month_normal:
-        fig_monthly = create_monthly_sales_chart(df)
-        st.plotly_chart(fig_monthly, use_container_width=True)
-    with month_lagged:
-        fig_monthly_log = create_monthly_sales_chart(df, log_y=True)
-        st.plotly_chart(fig_monthly_log, use_container_width=True)
+    show_month_lag = st.toggle("Show Lagged Values", key="month_lag_toggle")
+    fig_monthly = create_monthly_sales_chart(df, log_y=show_month_lag)
+    st.plotly_chart(fig_monthly, use_container_width=True)
 
     st.markdown("### 💰 Monthly Average Price Trend by Fuel Type")
     


### PR DESCRIPTION
## Summary
- Replace vertical region bars with horizontal gradient chart and remove legend
- Add toggle controls for showing lagged values across product, region-product, and monthly trend charts
- Simplify lagged Y-axis tick labels to key milestones via shared helper

## Testing
- `python -m py_compile main_final.py`


------
https://chatgpt.com/codex/tasks/task_e_6895220a293c832aaf54ebeb45299024