### PR TITLE
Refine charts with toggles and streamlined scales

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1011,6 +1011,23 @@ def create_comprehensive_data_overview(df):
         else:
             return str(int(value))
 
+    def generate_log_ticks(max_val: float) -> list:
+        """Generate custom tick values for log-scaled axes.
+
+        Starts from 90M, then 100M, proceeds in 100M steps up to 1B,
+        and continues in 1B increments afterwards.
+        """
+        ticks = [90_000_000, 100_000_000]
+        current = 200_000_000
+        while current < 1_000_000_000 and current <= max_val:
+            ticks.append(current)
+            current += 100_000_000
+        current = 1_000_000_000
+        while current <= max_val:
+            ticks.append(current)
+            current += 1_000_000_000
+        return ticks
+
     # Visualizations
     st.markdown("### 📊 Sales Volume Analysis")
     
@@ -1029,16 +1046,17 @@ def create_comprehensive_data_overview(df):
         
         fig_region = px.bar(
             data_frame=region_df,
-            x='Region',
-            y='sales_volume',
+            x='sales_volume',
+            y='Region',
+            orientation='h',
             title='Total Weekly Sales Volume by Region',
             labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
             color='sales_volume',
-            color_continuous_scale='viridis',
+            color_continuous_scale='Blues',
             custom_data='formatted_volume'
         )
         fig_region.update_traces(
-            hovertemplate='Region: %{x}<br>Sales Volume: %{y:.2f} (%{customdata})<extra></extra>'
+            hovertemplate='Region: %{y}<br>Sales Volume: %{x:.2f} (%{customdata})<extra></extra>'
         )
         fig_region.update_layout(
             height=500,
@@ -1046,11 +1064,12 @@ def create_comprehensive_data_overview(df):
             template='plotly_white',
             font=dict(size=14),
             title_font_size=18,
+            xaxis_title='Weekly Sales Volume (Litres)',
             xaxis_title_font_size=14,
-            yaxis_title='Weekly Sales Volume (Litres)',
-            yaxis_title_font_size=14
+            yaxis_title=None,
+            coloraxis_showscale=False
         )
-        fig_region.update_xaxes(tickangle=45)
+        fig_region.update_yaxes(categoryorder='total ascending')
         return fig_region
     
     @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -1075,7 +1094,7 @@ def create_comprehensive_data_overview(df):
             title='Total Sales Volume by Product',
             labels={'sales_volume': 'Sales Volume (Litres)'},
             color='sales_volume',
-            color_continuous_scale='plasma',
+            color_continuous_scale='Blues',
             custom_data='formatted_volume',
             log_y=log_y
         )
@@ -1095,7 +1114,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = product_df['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = generate_log_ticks(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_product.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_product.update_xaxes(tickangle=45)
@@ -1110,6 +1129,7 @@ def create_comprehensive_data_overview(df):
             x='Region',
             y='sales_volume',
             color='Product',
+            color_discrete_sequence=px.colors.qualitative.Dark24,
             barmode='group',
             title='Sales Volume by Region and Product',
             labels={'sales_volume': 'Sales Volume (Litres)'},
@@ -1127,7 +1147,7 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = rp_data['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = generate_log_ticks(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_rp.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_rp.update_xaxes(tickangle=45)
@@ -1139,21 +1159,13 @@ def create_comprehensive_data_overview(df):
         st.plotly_chart(fig_region, use_container_width=True)
     with tab_product:
         product_df = create_product_volume_chart(df)
-        sub_normal, sub_lagged = st.tabs(["Normal", "Lagged"])
-        with sub_normal:
-            fig_product = create_product_chart(product_df)
-            st.plotly_chart(fig_product, use_container_width=True)
-        with sub_lagged:
-            fig_product_lag = create_product_chart(product_df, log_y=True)
-            st.plotly_chart(fig_product_lag, use_container_width=True)
+        show_lagged = st.toggle("Show lagged values", key="prod_lag_toggle")
+        fig_product = create_product_chart(product_df, log_y=show_lagged)
+        st.plotly_chart(fig_product, use_container_width=True)
     with tab_region_product:
-        rp_normal, rp_lagged = st.tabs(["Normal", "Lagged"])
-        with rp_normal:
-            fig_rp = create_region_product_chart(df)
-            st.plotly_chart(fig_rp, use_container_width=True)
-        with rp_lagged:
-            fig_rp_log = create_region_product_chart(df, log_y=True)
-            st.plotly_chart(fig_rp_log, use_container_width=True)
+        show_rp_lagged = st.toggle("Show lagged values", key="rp_lag_toggle")
+        fig_rp = create_region_product_chart(df, log_y=show_rp_lagged)
+        st.plotly_chart(fig_rp, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1177,6 +1189,7 @@ def create_comprehensive_data_overview(df):
             x='week_start',
             y='sales_volume',
             color='Product',
+            color_discrete_sequence=px.colors.qualitative.Dark24,
             title='Monthly Sales Volume Trend by Fuel Type',
             labels={'week_start': 'Month', 'sales_volume': 'Monthly Sales Volume (Litres)', 'Product': 'Fuel Type'},
             custom_data='formatted_volume',
@@ -1192,19 +1205,15 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = df_monthly['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = generate_log_ticks(max_val)
             tick_text = [format_tick(v) for v in tick_vals]
             fig_monthly.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly
 
-    month_normal, month_lagged = st.tabs(["Normal", "Lagged"])
-    with month_normal:
-        fig_monthly = create_monthly_sales_chart(df)
-        st.plotly_chart(fig_monthly, use_container_width=True)
-    with month_lagged:
-        fig_monthly_log = create_monthly_sales_chart(df, log_y=True)
-        st.plotly_chart(fig_monthly_log, use_container_width=True)
+    show_monthly_lagged = st.toggle("Show lagged values", key="monthly_lag_toggle")
+    fig_monthly = create_monthly_sales_chart(df, log_y=show_monthly_lagged)
+    st.plotly_chart(fig_monthly, use_container_width=True)
 
     st.markdown("### 💰 Monthly Average Price Trend by Fuel Type")
     


### PR DESCRIPTION
## Summary
- Render regional sales as horizontal bars in a muted blue palette and hide colorbar legend
- Add custom tick generator for lagged views to show only major volume markers
- Replace Normal/Lagged tabs with toggles across product, region-product, and monthly trend charts

## Testing
- `python -m py_compile main_final.py`
- `pip install streamlit` *(fails: Could not find a version that satisfies the requirement streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68952174d58c832aa0f4686051b55894