### PR TITLE
Refine sales visuals with icon-based toggles

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1016,29 +1016,31 @@ def create_comprehensive_data_overview(df):
     
     # Create region and product charts with caching
     @st.cache_data(ttl=3600)  # Cache for 1 hour
-    def create_region_volume_chart(df):
+    def create_region_volume_chart(df, log_scale=False):
         # Sales volume by region
         region_volume = df.groupby('Region')['sales_volume'].sum().sort_values(ascending=False)
-        
+
         # Create a DataFrame for px.bar
         region_df = pd.DataFrame({
             'Region': region_volume.index,
             'sales_volume': region_volume.values,
             'formatted_volume': [format_value_with_unit(val) for val in region_volume.values]
         })
-        
+
         fig_region = px.bar(
             data_frame=region_df,
-            x='Region',
-            y='sales_volume',
+            x='sales_volume',
+            y='Region',
+            orientation='h',
             title='Total Weekly Sales Volume by Region',
             labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
             color='sales_volume',
-            color_continuous_scale='viridis',
-            custom_data='formatted_volume'
+            color_continuous_scale=px.colors.sequential.Blues,
+            custom_data='formatted_volume',
+            log_x=log_scale
         )
         fig_region.update_traces(
-            hovertemplate='Region: %{x}<br>Sales Volume: %{y:.2f} (%{customdata})<extra></extra>'
+            hovertemplate='Region: %{y}<br>Sales Volume: %{x:.2f} (%{customdata})<extra></extra>'
         )
         fig_region.update_layout(
             height=500,
@@ -1046,11 +1048,20 @@ def create_comprehensive_data_overview(df):
             template='plotly_white',
             font=dict(size=14),
             title_font_size=18,
+            xaxis_title='Weekly Sales Volume (Litres)',
             xaxis_title_font_size=14,
-            yaxis_title='Weekly Sales Volume (Litres)',
-            yaxis_title_font_size=14
+            yaxis_title=None,
+            coloraxis_showscale=False,
+            showlegend=False
         )
-        fig_region.update_xaxes(tickangle=45)
+        if log_scale:
+            max_val = region_df['sales_volume'].max()
+            tick_vals = [9e7, 1e8, 2e8, 3e8, 4e8]
+            i = 1
+            while 1e9 * i <= max_val:
+                tick_vals.append(1e9 * i)
+                i += 1
+            fig_region.update_xaxes(tickvals=tick_vals, ticktext=[format_tick(v) for v in tick_vals])
         return fig_region
     
     @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -1133,27 +1144,32 @@ def create_comprehensive_data_overview(df):
         fig_rp.update_xaxes(tickangle=45)
         return fig_rp
 
-    tab_region, tab_product, tab_region_product = st.tabs(["By Region", "By Product", "Region vs Product"])
-    with tab_region:
-        fig_region = create_region_volume_chart(df)
+    view_mode = st.radio("View Mode", ["Normal", "Lagged"], horizontal=True, key="sales_view_mode")
+
+    icon_map = {
+        "Region": "🌍",
+        "Product": "📦",
+        "Region vs Product": "🌍📦"
+    }
+    selected_view = st.radio(
+        "Sales Volume View",
+        list(icon_map.keys()),
+        format_func=lambda x: icon_map[x],
+        horizontal=True,
+        label_visibility="collapsed"
+    )
+
+    lag = view_mode == "Lagged"
+    if selected_view == "Region":
+        fig_region = create_region_volume_chart(df, log_scale=lag)
         st.plotly_chart(fig_region, use_container_width=True)
-    with tab_product:
+    elif selected_view == "Product":
         product_df = create_product_volume_chart(df)
-        sub_normal, sub_lagged = st.tabs(["Normal", "Lagged"])
-        with sub_normal:
-            fig_product = create_product_chart(product_df)
-            st.plotly_chart(fig_product, use_container_width=True)
-        with sub_lagged:
-            fig_product_lag = create_product_chart(product_df, log_y=True)
-            st.plotly_chart(fig_product_lag, use_container_width=True)
-    with tab_region_product:
-        rp_normal, rp_lagged = st.tabs(["Normal", "Lagged"])
-        with rp_normal:
-            fig_rp = create_region_product_chart(df)
-            st.plotly_chart(fig_rp, use_container_width=True)
-        with rp_lagged:
-            fig_rp_log = create_region_product_chart(df, log_y=True)
-            st.plotly_chart(fig_rp_log, use_container_width=True)
+        fig_product = create_product_chart(product_df, log_y=lag)
+        st.plotly_chart(fig_product, use_container_width=True)
+    else:
+        fig_rp = create_region_product_chart(df, log_y=lag)
+        st.plotly_chart(fig_rp, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1192,19 +1208,19 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = df_monthly['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = [90_000_000, 100_000_000, 200_000_000, 300_000_000, 400_000_000]
+            i = 1
+            while 1_000_000_000 * i <= max_val:
+                tick_vals.append(1_000_000_000 * i)
+                i += 1
             tick_text = [format_tick(v) for v in tick_vals]
             fig_monthly.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly
 
-    month_normal, month_lagged = st.tabs(["Normal", "Lagged"])
-    with month_normal:
-        fig_monthly = create_monthly_sales_chart(df)
-        st.plotly_chart(fig_monthly, use_container_width=True)
-    with month_lagged:
-        fig_monthly_log = create_monthly_sales_chart(df, log_y=True)
-        st.plotly_chart(fig_monthly_log, use_container_width=True)
+    monthly_mode = st.radio("View Mode", ["Normal", "Lagged"], horizontal=True, key="monthly_view_mode")
+    fig_monthly = create_monthly_sales_chart(df, log_y=monthly_mode == "Lagged")
+    st.plotly_chart(fig_monthly, use_container_width=True)
 
     st.markdown("### 💰 Monthly Average Price Trend by Fuel Type")
     


### PR DESCRIPTION
## Summary
- Switch region sales chart to a compact horizontal bar chart with a subtle blue gradient and no legend
- Replace tabbed navigation with icon-based controls and a unified View Mode toggle for normal vs lagged data
- Simplify monthly trend lagged view with milestone tick labels and its own View Mode toggle

## Testing
- `python -m py_compile main_final.py`

------
https://chatgpt.com/codex/tasks/task_e_689523cdaac4832ab6a6a9da68756800