### PR TITLE
Streamline sales volume analysis visuals

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -1016,29 +1016,32 @@ def create_comprehensive_data_overview(df):
     
     # Create region and product charts with caching
     @st.cache_data(ttl=3600)  # Cache for 1 hour
-    def create_region_volume_chart(df):
+    def create_region_volume_chart(df, log_y=False):
         # Sales volume by region
         region_volume = df.groupby('Region')['sales_volume'].sum().sort_values(ascending=False)
-        
+
         # Create a DataFrame for px.bar
         region_df = pd.DataFrame({
             'Region': region_volume.index,
             'sales_volume': region_volume.values,
             'formatted_volume': [format_value_with_unit(val) for val in region_volume.values]
         })
-        
+
+        # Horizontal bar chart with subtle gradient colours and no legend
         fig_region = px.bar(
             data_frame=region_df,
-            x='Region',
-            y='sales_volume',
+            y='Region',
+            x='sales_volume',
             title='Total Weekly Sales Volume by Region',
             labels={'sales_volume': 'Weekly Sales Volume (Litres)'},
             color='sales_volume',
-            color_continuous_scale='viridis',
-            custom_data='formatted_volume'
+            color_continuous_scale='Blues',
+            custom_data='formatted_volume',
+            orientation='h',
+            log_x=log_y
         )
         fig_region.update_traces(
-            hovertemplate='Region: %{x}<br>Sales Volume: %{y:.2f} (%{customdata})<extra></extra>'
+            hovertemplate='Region: %{y}<br>Sales Volume: %{x:.2f} (%{customdata})<extra></extra>'
         )
         fig_region.update_layout(
             height=500,
@@ -1046,11 +1049,17 @@ def create_comprehensive_data_overview(df):
             template='plotly_white',
             font=dict(size=14),
             title_font_size=18,
+            xaxis_title='Weekly Sales Volume (Litres)',
             xaxis_title_font_size=14,
-            yaxis_title='Weekly Sales Volume (Litres)',
-            yaxis_title_font_size=14
+            yaxis_title=None,
+            showlegend=False,
+            coloraxis_showscale=False
         )
-        fig_region.update_xaxes(tickangle=45)
+        if log_y:
+            max_val = region_df['sales_volume'].max()
+            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_text = [format_tick(v) for v in tick_vals]
+            fig_region.update_xaxes(tickvals=tick_vals, ticktext=tick_text)
         return fig_region
     
     @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -1133,27 +1142,29 @@ def create_comprehensive_data_overview(df):
         fig_rp.update_xaxes(tickangle=45)
         return fig_rp
 
-    tab_region, tab_product, tab_region_product = st.tabs(["By Region", "By Product", "Region vs Product"])
-    with tab_region:
-        fig_region = create_region_volume_chart(df)
+    icon_options = {
+        "By Region": "🌐",
+        "By Product": "📦",
+        "Region vs Product": "🌐📦"
+    }
+    analysis_view = st.radio(
+        "",
+        options=list(icon_options.keys()),
+        format_func=lambda x: icon_options[x],
+        horizontal=True
+    )
+    view_mode = st.radio("View Mode", ["Normal", "Lagged"], horizontal=True, key="analysis_view_mode")
+
+    if analysis_view == "By Region":
+        fig_region = create_region_volume_chart(df, log_y=view_mode == "Lagged")
         st.plotly_chart(fig_region, use_container_width=True)
-    with tab_product:
+    elif analysis_view == "By Product":
         product_df = create_product_volume_chart(df)
-        sub_normal, sub_lagged = st.tabs(["Normal", "Lagged"])
-        with sub_normal:
-            fig_product = create_product_chart(product_df)
-            st.plotly_chart(fig_product, use_container_width=True)
-        with sub_lagged:
-            fig_product_lag = create_product_chart(product_df, log_y=True)
-            st.plotly_chart(fig_product_lag, use_container_width=True)
-    with tab_region_product:
-        rp_normal, rp_lagged = st.tabs(["Normal", "Lagged"])
-        with rp_normal:
-            fig_rp = create_region_product_chart(df)
-            st.plotly_chart(fig_rp, use_container_width=True)
-        with rp_lagged:
-            fig_rp_log = create_region_product_chart(df, log_y=True)
-            st.plotly_chart(fig_rp_log, use_container_width=True)
+        fig_product = create_product_chart(product_df, log_y=view_mode == "Lagged")
+        st.plotly_chart(fig_product, use_container_width=True)
+    else:
+        fig_rp = create_region_product_chart(df, log_y=view_mode == "Lagged")
+        st.plotly_chart(fig_rp, use_container_width=True)
 
     # Time series analysis
     st.markdown("### 📈 Monthly Sales Volume Trend")
@@ -1192,19 +1203,22 @@ def create_comprehensive_data_overview(df):
         )
         if log_y:
             max_val = df_monthly['sales_volume'].max()
-            tick_vals = [9e7] + [1e8 * i for i in range(1, int(max_val / 1e8) + 2)]
+            tick_vals = [90_000_000]
+            current = 100_000_000
+            while current <= max_val:
+                tick_vals.append(current)
+                if current < 1_000_000_000:
+                    current += 100_000_000
+                else:
+                    current += 1_000_000_000
             tick_text = [format_tick(v) for v in tick_vals]
             fig_monthly.update_yaxes(tickvals=tick_vals, ticktext=tick_text)
         fig_monthly.update_xaxes(tickangle=45)
         return fig_monthly
 
-    month_normal, month_lagged = st.tabs(["Normal", "Lagged"])
-    with month_normal:
-        fig_monthly = create_monthly_sales_chart(df)
-        st.plotly_chart(fig_monthly, use_container_width=True)
-    with month_lagged:
-        fig_monthly_log = create_monthly_sales_chart(df, log_y=True)
-        st.plotly_chart(fig_monthly_log, use_container_width=True)
+    monthly_view_mode = st.radio("View Mode", ["Normal", "Lagged"], horizontal=True, key="monthly_view")
+    fig_monthly = create_monthly_sales_chart(df, log_y=monthly_view_mode == "Lagged")
+    st.plotly_chart(fig_monthly, use_container_width=True)
 
     st.markdown("### 💰 Monthly Average Price Trend by Fuel Type")
     


### PR DESCRIPTION
## Summary
- Use a horizontal, legend-free region bar chart with subtle blue gradient
- Replace tabbed sales volume views with icon navigation and a unified view-mode toggle
- Simplify monthly trend lagged axis ticks and add toggle for normal vs lagged values

## Testing
- `python -m py_compile main_final.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689523cdaac4832ab6a6a9da68756800