### PR TITLE
Incorporate lag features for trend-aware forecasting

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -534,13 +534,18 @@ def enhanced_feature_engineering(df, forecasting_mode=False):
                                        np.nan)
 
     # External factors
-    # Remove fixed seed to allow for true randomness in forecasting
-    # Only use fixed seed during initial feature engineering, not during forecasting
-    if not forecasting_mode:
-        np.random.seed(42)  # Keep deterministic behavior for initial data processing
-    df['weather_factor'] = np.random.normal(1, 0.1, len(df))
-    df['economic_factor'] = np.random.normal(1, 0.05, len(df))
-    df['event_factor'] = np.random.normal(1, 0.15, len(df))
+    # During model training we keep a fixed seed for reproducibility, while
+    # forecasting uses deterministic placeholders to avoid introducing
+    # unpredictable noise.
+    if forecasting_mode:
+        df['weather_factor'] = 1.0
+        df['economic_factor'] = 1.0
+        df['event_factor'] = 1.0
+    else:
+        np.random.seed(42)
+        df['weather_factor'] = np.random.normal(1, 0.1, len(df))
+        df['economic_factor'] = np.random.normal(1, 0.05, len(df))
+        df['event_factor'] = np.random.normal(1, 0.15, len(df))
 
     # Additional rolling stats on sales_volume
     for window in [4, 8, 12]:
@@ -550,6 +555,10 @@ def enhanced_feature_engineering(df, forecasting_mode=False):
         df[f'roll{window}_std'] = df.groupby(['Region', 'Product'])['sales_volume'].transform(
             lambda x: x.rolling(window, min_periods=1).std()
         )
+
+    # Lag features to capture recent momentum
+    df['lag_1'] = df.groupby(['Region', 'Product'])['sales_volume'].shift(1)
+    df['lag_2'] = df.groupby(['Region', 'Product'])['sales_volume'].shift(2)
 
     return df
 
@@ -570,26 +579,25 @@ def evaluate_preds(y_true, y_pred):
 
 def generate_forecast(res, group_eng, product, forecast_weeks, forecast_method,
                       include_confidence, confidence_level):
-    """Replicate the original detailed forecasting logic.
+    """Generate forecasts recursively using models trained on the full dataset.
 
-    This function mirrors the extensive forecasting routine previously embedded
-    in the training loop. It regenerates time and seasonal features, applies
-    product-specific randomisation and handles both direct and recursive
-    strategies while optionally producing confidence intervals.
+    The previous implementation injected substantial random noise and treated
+    each horizon independently.  This version produces sequential forecasts by
+    feeding each prediction back into the feature set so that temporal
+    dependencies are respected.  Confidence intervals are derived from the
+    empirical standard deviation of validation residuals.
     """
 
     models = res.get('models', {})
     lgbm = models.get('lgbm')
     rf = models.get('rf')
-    metrics = res.get('metrics', {})
-    y_test = res.get('y_test', pd.Series(dtype=float))
     imputer = res.get('imputer')
     selector = res.get('selector')
     feature_cols = res.get('feature_cols', [])
-    selected_features = res.get('selected_features', [])
     feature_selection_enabled = res.get('feature_selection_enabled', False)
     ensemble_method = res.get('ensemble_method', 'Average')
     lgbm_weight = res.get('lgbm_weight', 0.5)
+    resid_std = res.get('residual_std', 0.0)
 
     if not feature_cols or lgbm is None or rf is None or imputer is None:
         return {
@@ -603,217 +611,94 @@ def generate_forecast(res, group_eng, product, forecast_weeks, forecast_method,
             'confidence_level': confidence_level if include_confidence else None,
         }
 
-    group_eng = group_eng.copy()
+    group_eng = group_eng.copy().sort_values('week_start')
     if not pd.api.types.is_datetime64_any_dtype(group_eng['week_start']):
         group_eng['week_start'] = pd.to_datetime(group_eng['week_start'])
 
-    last_data = group_eng.iloc[-1:].copy()
-    last_date = pd.to_datetime(last_data['week_start'].iloc[0])
+    last_row = group_eng.iloc[-1:].copy()
+    last_date = pd.to_datetime(last_row['week_start'].iloc[0])
+
+    # history of sales for lag and rolling features
+    history = group_eng['sales_volume'].tolist()
 
     forecast_dates = [last_date + timedelta(days=7 * i) for i in range(1, forecast_weeks + 1)]
-    forecast_values = []
-    lower_bounds = []
-    upper_bounds = []
+    forecasts, lower_bounds, upper_bounds = [], [], []
 
-    if forecast_method == 'Direct':
-        for i in range(forecast_weeks):
-            future_data = last_data.copy()
-            future_data['week_start'] = forecast_dates[i]
-            future_data['week_start'] = pd.to_datetime(future_data['week_start'])
-            future_data['month'] = future_data['week_start'].dt.month
-            future_data['year'] = future_data['week_start'].dt.year
-            future_data['week_of_year'] = future_data['week_start'].dt.isocalendar().week
-            future_data['seasonal_sin'] = np.sin(2 * np.pi * future_data['week_of_year'] / 52)
-            future_data['seasonal_cos'] = np.cos(2 * np.pi * future_data['week_of_year'] / 52)
-            future_data['quarterly_sin'] = np.sin(2 * np.pi * future_data['week_of_year'] / 13)
-            future_data['quarterly_cos'] = np.cos(2 * np.pi * future_data['week_of_year'] / 13)
-            future_data['monthly_sin'] = np.sin(2 * np.pi * future_data['month'] / 12)
-            future_data['monthly_cos'] = np.cos(2 * np.pi * future_data['month'] / 12)
-            future_data['trend_factor'] = future_data['week_of_year'] / 52
-            future_data['trend_squared'] = (future_data['week_of_year'] / 52) ** 2
-            future_data['price_change'] = 0
+    for i, f_date in enumerate(forecast_dates):
+        row = last_row.copy()
+        row['week_start'] = f_date
+        row['month'] = f_date.month
+        row['year'] = f_date.year
+        row['week_of_year'] = f_date.isocalendar().week
+        row['seasonal_sin'] = np.sin(2 * np.pi * row['week_of_year'] / 52)
+        row['seasonal_cos'] = np.cos(2 * np.pi * row['week_of_year'] / 52)
+        row['quarterly_sin'] = np.sin(2 * np.pi * row['week_of_year'] / 13)
+        row['quarterly_cos'] = np.cos(2 * np.pi * row['week_of_year'] / 13)
+        row['monthly_sin'] = np.sin(2 * np.pi * row['month'] / 12)
+        row['monthly_cos'] = np.cos(2 * np.pi * row['month'] / 12)
+        row['trend_factor'] = row['week_of_year'] / 52
+        row['trend_squared'] = (row['week_of_year'] / 52) ** 2
 
-            is_hobc = product == 'HOBC'
-            historical_volatility = metrics.get('RMSE', 0) / y_test.mean() if len(y_test) > 0 and y_test.mean() > 0 else 0.05
-            base_variation_factor = max(0.02, historical_volatility * 0.3) * (1 + i * 0.15)
-            if is_hobc:
-                variation_factor = base_variation_factor * 3.0
-                min_absolute_variation = 1000
-            else:
-                variation_factor = base_variation_factor * 1.5
-                min_absolute_variation = 250
+        # Rolling statistics and lag features based on history
+        for window in [4, 8, 12]:
+            row[f'roll{window}_mean'] = np.mean(history[-window:])
+            row[f'roll{window}_std'] = np.std(history[-window:]) if window > 1 else 0.0
 
-            relative_change = np.random.normal(0, variation_factor)
-            future_data['volume_change'] = relative_change
+        row['volume_trend'] = np.mean(history[-8:])
+        row['volume_volatility'] = np.std(history[-4:]) if len(history) > 1 else 0.0
+        row['volume_change'] = (history[-1] - history[-2]) / history[-2] if len(history) > 1 and history[-2] != 0 else 0.0
+        row['regional_trend'] = np.mean(history[-12:])
+        row['product_trend'] = np.mean(history[-12:])
+        row['lag_1'] = history[-1]
+        row['lag_2'] = history[-2] if len(history) > 1 else history[-1]
 
-            if len(y_test) > 1:
-                historical_trend = 1 if y_test.iloc[-1] > y_test.iloc[0] else -1
-                trend_strength = min(1.0, abs(y_test.iloc[-1] - y_test.iloc[0]) / (y_test.mean() + 1e-10))
-            else:
-                historical_trend = 1
-                trend_strength = 0.5
+        # Preserve last known values for price-based features and recompute ratios
+        row['price_change'] = 0.0
+        for col in ['weather_factor', 'economic_factor', 'event_factor']:
+            if col in row.columns:
+                row[col] = 1.0
+        if 'avg_price' in row.columns:
+            row['price_elasticity'] = row['lag_1'] / row['avg_price'] if row['avg_price'] != 0 else np.nan
+            row['price_volume_ratio'] = row['avg_price'] * row['lag_1']
+            row['price_over_volume'] = row['avg_price'] / row['lag_1'] if row['lag_1'] != 0 else np.nan
 
-            volatility_factor = 0.02 * (i + 1) * (3.0 if is_hobc else 1.0)
-            trend_factor = 0.03 * (i + 1) * (3.0 if is_hobc else 1.0)
-            regional_product_factor = 0.01 * (i + 1) * (3.0 if is_hobc else 1.0)
-            trend_bias = historical_trend * trend_strength * 0.01 * (i + 1)
+        X_future = row[feature_cols]
+        X_clean = pd.DataFrame(imputer.transform(X_future), columns=feature_cols, index=[0])
+        if feature_selection_enabled and selector is not None:
+            X_sel = selector.transform(X_clean)
+        else:
+            X_sel = X_clean.values
 
-            future_data['price_volatility'] *= (1 + np.random.normal(trend_bias, volatility_factor))
-            future_data['volume_trend'] *= (1 + np.random.normal(trend_bias * 1.5, trend_factor))
-            future_data['volume_volatility'] *= (1 + np.random.normal(trend_bias, volatility_factor))
-            future_data['regional_trend'] *= (1 + np.random.normal(trend_bias, regional_product_factor))
-            future_data['product_trend'] *= (1 + np.random.normal(trend_bias, regional_product_factor))
+        pred_lgbm = lgbm.predict(X_sel)
+        pred_rf = rf.predict(X_sel)
+        if ensemble_method == "Weighted Average":
+            forecast_val = lgbm_weight * pred_lgbm[0] + (1 - lgbm_weight) * pred_rf[0]
+        else:
+            forecast_val = (pred_lgbm[0] + pred_rf[0]) / 2
 
-            rolling_factor = 0.02 * (i + 1) * (3.0 if is_hobc else 1.0)
-            for window in [4, 8, 12]:
-                if f'roll{window}_mean' in future_data.columns:
-                    window_adjusted_factor = rolling_factor * (1.0 + (1.0 / window))
-                    window_trend_bias = trend_bias * (1.0 + (1.0 / window))
-                    mean_change = np.random.normal(window_trend_bias, window_adjusted_factor)
-                    future_data[f'roll{window}_mean'] *= (1 + mean_change)
-                    if is_hobc:
-                        abs_variation = min_absolute_variation * (1.0 + (0.5 / window))
-                        direction_prob = 0.5 + (0.3 * historical_trend)
-                        direction = np.random.choice([-1, 1], p=[1-direction_prob, direction_prob]) if historical_trend > 0 else np.random.choice([-1, 1], p=[direction_prob, 1-direction_prob])
-                        future_data[f'roll{window}_mean'] += direction * abs_variation
-                    elif min_absolute_variation > 0:
-                        direction_prob = 0.5 + (0.2 * historical_trend)
-                        direction = np.random.choice([-1, 1], p=[1-direction_prob, direction_prob]) if historical_trend > 0 else np.random.choice([-1, 1], p=[direction_prob, 1-direction_prob])
-                        future_data[f'roll{window}_mean'] += direction * min_absolute_variation * (0.5 + (0.2 / window))
+        forecasts.append(forecast_val)
+        history.append(forecast_val)
 
-                if f'roll{window}_std' in future_data.columns:
-                    std_factor = rolling_factor * (1.0 + historical_volatility)
-                    future_data[f'roll{window}_std'] *= (1 + np.random.normal(0, std_factor))
-                    min_std = min_absolute_variation * 0.2 * historical_volatility if is_hobc else min_absolute_variation * 0.1 * historical_volatility
-                    if min_std > 0:
-                        future_data[f'roll{window}_std'] = future_data[f'roll{window}_std'].clip(lower=min_std)
+        if include_confidence:
+            z = {0.8: 1.28, 0.85: 1.44, 0.9: 1.645, 0.95: 1.96, 0.99: 2.58}.get(confidence_level, 1.96)
+            margin = z * resid_std * np.sqrt(i + 1)
+            lower_bounds.append(max(0, forecast_val - margin))
+            upper_bounds.append(forecast_val + margin)
+        else:
+            lower_bounds.append(None)
+            upper_bounds.append(None)
 
-            X_future = future_data[feature_cols]
-            X_future_clean = pd.DataFrame(imputer.transform(X_future), columns=feature_cols, index=X_future.index)
-            if feature_selection_enabled and selector is not None:
-                X_future_sel = selector.transform(X_future_clean)
-            else:
-                X_future_sel = X_future_clean.values
-            X_future_sel = np.nan_to_num(X_future_sel, nan=0.0, posinf=0.0, neginf=0.0)
-
-            pred_lgbm_future = lgbm.predict(X_future_sel)
-            pred_rf_future = rf.predict(X_future_sel)
-            if ensemble_method == "Weighted Average":
-                ensemble_pred_future = (lgbm_weight * pred_lgbm_future) + ((1 - lgbm_weight) * pred_rf_future)
-            else:
-                ensemble_pred_future = (pred_lgbm_future + pred_rf_future) / 2
-
-            forecast_values.append(ensemble_pred_future[0])
-
-            if include_confidence:
-                mae = metrics.get('MAE', 0)
-                rmse = metrics.get('RMSE', 0)
-                error_estimate = (0.7 * mae) + (0.3 * rmse)
-                z_score = 1.96
-                if confidence_level == 0.99:
-                    z_score = 2.58
-                elif confidence_level == 0.9:
-                    z_score = 1.645
-                elif confidence_level == 0.85:
-                    z_score = 1.44
-                elif confidence_level == 0.8:
-                    z_score = 1.28
-                if is_hobc:
-                    step_factor = 1 + (i * 0.2)
-                    min_margin = 2000 * (i + 1)
-                else:
-                    step_factor = 1 + (i * 0.1)
-                    min_margin = 0
-                margin = max(z_score * error_estimate * step_factor, min_margin)
-                forecast_value = max(ensemble_pred_future[0], margin/2)
-                forecast_values[-1] = forecast_value
-                lower_bounds.append(max(0, forecast_value - margin))
-                upper_bounds.append(forecast_value + margin)
-            else:
-                lower_bounds.append(None)
-                upper_bounds.append(None)
-
-    else:  # Recursive
-        current_data = last_data.copy()
-        prediction_history = []
-        for i in range(forecast_weeks):
-            current_data['week_start'] = forecast_dates[i]
-            current_data['week_start'] = pd.to_datetime(current_data['week_start'])
-            current_data['month'] = current_data['week_start'].dt.month
-            current_data['year'] = current_data['week_start'].dt.year
-            current_data['week_of_year'] = current_data['week_start'].dt.isocalendar().week
-
-            for col in current_data.columns:
-                if current_data[col].dtype.kind in 'fc':
-                    current_data[col] = current_data[col].replace([np.inf, -np.inf], np.nan)
-                    if current_data[col].isna().any():
-                        if current_data[col].notna().any():
-                            current_data[col] = current_data[col].fillna(current_data[col].mean())
-                        else:
-                            current_data[col] = current_data[col].fillna(0)
-
-            X_future = current_data[feature_cols]
-            X_future = X_future.replace([np.inf, -np.inf], np.nan)
-            X_future = X_future.fillna(X_future.mean())
-            X_future_clean = pd.DataFrame(imputer.transform(X_future), columns=feature_cols, index=X_future.index)
-            X_future_clean = X_future_clean.replace([np.inf, -np.inf], np.nan)
-            X_future_clean = X_future_clean.fillna(X_future_clean.mean())
-            if feature_selection_enabled and selector is not None:
-                X_future_sel = selector.transform(X_future_clean)
-            else:
-                X_future_sel = X_future_clean.values
-            X_future_sel = np.nan_to_num(X_future_sel, nan=0.0, posinf=0.0, neginf=0.0)
-
-            pred_lgbm_future = lgbm.predict(X_future_sel)
-            pred_rf_future = rf.predict(X_future_sel)
-            if ensemble_method == "Weighted Average":
-                ensemble_pred_future = (lgbm_weight * pred_lgbm_future) + ((1 - lgbm_weight) * pred_rf_future)
-            else:
-                ensemble_pred_future = (pred_lgbm_future + pred_rf_future) / 2
-
-            forecast_value = ensemble_pred_future[0]
-            if i > 0 and len(prediction_history) > 0:
-                trend_direction = 1 if prediction_history[-1] > prediction_history[0] else -1
-                seasonal_factor = (current_data.get('seasonal_sin', 0) + current_data.get('monthly_sin', 0)) / 2
-                if product == 'HOBC':
-                    rand_factor = np.random.normal(trend_direction * 0.05 + seasonal_factor * 0.03, 0.08)
-                    forecast_value = max(100, forecast_value * (1 + rand_factor))
-                else:
-                    rand_factor = np.random.normal(trend_direction * 0.03 + seasonal_factor * 0.02, 0.05)
-                    forecast_value = max(100, forecast_value * (1 + rand_factor))
-
-            forecast_values.append(forecast_value)
-            prediction_history.append(forecast_value)
-            current_data['sales_volume'] = forecast_value
-
-            if include_confidence:
-                mae = metrics.get('MAE', 0)
-                rmse = metrics.get('RMSE', 0)
-                error_estimate = (0.7 * mae) + (0.3 * rmse)
-                z_score = 1.96
-                if confidence_level == 0.99:
-                    z_score = 2.58
-                elif confidence_level == 0.9:
-                    z_score = 1.645
-                elif confidence_level == 0.85:
-                    z_score = 1.44
-                elif confidence_level == 0.8:
-                    z_score = 1.28
-                step_factor = 1 + 0.1 * (i + 1)
-                margin = z_score * error_estimate * step_factor
-                lower_bounds.append(max(0, forecast_value - margin))
-                upper_bounds.append(forecast_value + margin)
-            else:
-                lower_bounds.append(None)
-                upper_bounds.append(None)
+        # prepare row for next iteration
+        last_row = row.copy()
+        last_row['sales_volume'] = forecast_val
 
     return {
         'dates': forecast_dates,
         'dates_str': [d.strftime('%Y-%m-%d') for d in forecast_dates],
-        'values': forecast_values,
+        'values': forecasts,
         'lower_bounds': lower_bounds,
         'upper_bounds': upper_bounds,
-        'method': forecast_method,
+        'method': 'Recursive',
         'horizon': forecast_weeks,
         'confidence_level': confidence_level if include_confidence else None,
     }
@@ -2312,28 +2197,60 @@ def main():
                         
                         pred_lgbm = lgbm.predict(X_test_sel)
                         pred_rf = rf.predict(X_test_sel)
-                        
+
                         # Combine predictions based on ensemble method
                         if ensemble_method == "Weighted Average":
                             ensemble_pred = (lgbm_weight * pred_lgbm) + ((1 - lgbm_weight) * pred_rf)
                         else:  # Simple average
                             ensemble_pred = (pred_lgbm + pred_rf) / 2
-                        
+
                         metrics = evaluate_preds(y_test, ensemble_pred)
-                        
+                        residual_std = np.std(y_test - ensemble_pred)
+
+                        # Refit preprocessing and models on full dataset for forecasting
+                        X_full = group_eng[feature_cols]
+                        y_full = group_eng['sales_volume']
+                        imputer_full = SimpleImputer(strategy='mean')
+                        X_full_clean = pd.DataFrame(imputer_full.fit_transform(X_full), columns=feature_cols, index=X_full.index)
+                        if feature_selection_enabled:
+                            k = min(k_features, len(feature_cols))
+                            selector_full = SelectKBest(score_func=f_regression, k=k)
+                            X_full_sel = selector_full.fit_transform(X_full_clean, y_full)
+                            selected_features = X_full_clean.columns[selector_full.get_support()].tolist()
+                        else:
+                            X_full_sel = X_full_clean.values
+                            selector_full = None
+                            selected_features = feature_cols
+
+                        lgbm_full = lgb.LGBMRegressor(
+                            learning_rate=lgbm_learning_rate,
+                            n_estimators=lgbm_n_estimators,
+                            max_depth=lgbm_max_depth,
+                            random_state=42
+                        )
+                        rf_full = RandomForestRegressor(
+                            n_estimators=rf_n_estimators,
+                            max_depth=rf_max_depth,
+                            min_samples_split=rf_min_samples_split,
+                            random_state=42
+                        )
+                        lgbm_full.fit(X_full_sel, y_full)
+                        rf_full.fit(X_full_sel, y_full)
+
                         # Store model results
                         result_data = {
                             'metrics': metrics,
+                            'residual_std': residual_std,
                             'y_test': y_test,
                             'y_pred': ensemble_pred,
                             'test_data': test,
                             'selected_features': selected_features,
                             'models': {
-                                'lgbm': lgbm,
-                                'rf': rf
+                                'lgbm': lgbm_full,
+                                'rf': rf_full
                             },
-                            'imputer': imputer,
-                            'selector': selector if feature_selection_enabled else None,
+                            'imputer': imputer_full,
+                            'selector': selector_full,
                             'feature_cols': feature_cols,
                             'feature_selection_enabled': feature_selection_enabled,
                             'ensemble_method': ensemble_method,
@@ -2346,7 +2263,7 @@ def main():
                                 'split_method': split_method
                             }
                         }
-                        
+
                         rp_results[(region, product)] = result_data
                     
                     # Set progress to 100% when complete


### PR DESCRIPTION
## Summary
- Add lag-based features to engineered dataset to capture recent sales momentum
- Rework recursive forecasting loop to update rolling statistics, lags, and price ratios with each prediction for non-flat projections

## Testing
- `python -m py_compile main_final.py`


------
https://chatgpt.com/codex/tasks/task_e_6895413ec7bc832a851e3677bcc9a83b